### PR TITLE
Refactor EntityManager class and imports

### DIFF
--- a/src/core/entity-api-factory.ts
+++ b/src/core/entity-api-factory.ts
@@ -1,0 +1,124 @@
+/**
+ * EntityAPIFactory - EntityAPI Instance Management
+ * Responsible for creating and managing EntityAPI instances
+ * 
+ * This class handles:
+ * - EntityAPI instance creation with proper dependency injection
+ * - EntityAPI instance caching
+ * - Manager lifecycle management
+ */
+import { EntityAPI } from './entity-api';
+import { EntityManager } from './entity-manager';
+import { EntityDataManager } from './entity-data-manager';
+import { ValidationManager } from './validation-manager';
+import { PermissionManager } from './permission-manager';
+import { WorkflowManager } from './workflow-manager';
+import { DatabaseManager } from '../database/database-manager';
+
+/**
+ * EntityAPIFactory class - EntityAPI Instance Management
+ * 
+ * Single Responsibility: Create and manage EntityAPI instances
+ */
+export class EntityAPIFactory {
+  private entityManager: EntityManager;
+  private entityDataManager: EntityDataManager;
+  private validationManager: ValidationManager;
+  private permissionManager: PermissionManager;
+  private workflowManager: WorkflowManager;
+  
+  // EntityAPI instance cache
+  private entityApiCache = new Map<string, EntityAPI>();
+
+  /**
+   * Create a new EntityAPIFactory instance
+   * @param databaseManager Database manager for dependency injection
+   */
+  constructor(databaseManager: DatabaseManager) {
+    // Initialize all required managers with proper dependency injection
+    this.entityManager = new EntityManager(databaseManager);
+    this.entityDataManager = new EntityDataManager(databaseManager);
+    this.validationManager = new ValidationManager();
+    this.permissionManager = new PermissionManager(databaseManager.getAdapter());
+    this.workflowManager = new WorkflowManager(databaseManager.getAdapter());
+  }
+
+  /**
+   * Create EntityAPI instance for the given entity name with optional tenant context
+   * @param entityName Entity name
+   * @param tenantId Tenant ID (defaults to 'default')
+   * @returns EntityAPI instance
+   */
+  createEntityAPI(entityName: string, tenantId: string = 'default'): EntityAPI {
+    const cacheKey = `${tenantId}:${entityName}`;
+    
+    if (!this.entityApiCache.has(cacheKey)) {
+      // Create EntityAPI instance with proper dependency injection
+      const entityApi = new EntityAPI(
+        entityName,
+        this.entityManager,
+        this.entityDataManager,
+        this.validationManager,
+        this.permissionManager,
+        this.workflowManager,
+        tenantId
+      );
+      this.entityApiCache.set(cacheKey, entityApi);
+    }
+    
+    const cachedEntity = this.entityApiCache.get(cacheKey);
+    if (!cachedEntity) {
+      throw new Error(`Failed to retrieve cached entity API for ${cacheKey}`);
+    }
+    return cachedEntity;
+  }
+
+  /**
+   * Get the entity manager instance
+   */
+  getEntityManager(): EntityManager {
+    return this.entityManager;
+  }
+
+  /**
+   * Get the entity data manager instance
+   */
+  getEntityDataManager(): EntityDataManager {
+    return this.entityDataManager;
+  }
+
+  /**
+   * Clears the entity API cache for a specific entity or all entities
+   */
+  clearEntityApiCache(entityName?: string, tenantId?: string): void {
+    if (entityName && tenantId) {
+      const cacheKey = `${tenantId}:${entityName}`;
+      this.entityApiCache.delete(cacheKey);
+    } else if (entityName) {
+      // Clear all tenant variants of this entity
+      const keysToDelete = Array.from(this.entityApiCache.keys()).filter(key => key.endsWith(`:${entityName}`));
+      keysToDelete.forEach(key => this.entityApiCache.delete(key));
+    } else {
+      this.entityApiCache.clear();
+    }
+  }
+
+  /**
+   * Clear all caches (entity API and entity configuration)
+   */
+  clearAllCache(): void {
+    this.entityApiCache.clear();
+    this.entityManager.clearAllCache();
+  }
+
+  /**
+   * Get cache statistics
+   */
+  getCacheStats() {
+    return {
+      entityApiCacheSize: this.entityApiCache.size,
+      entityApiInstances: Array.from(this.entityApiCache.keys()),
+      entityManager: this.entityManager.getCacheStats()
+    };
+  }
+}

--- a/src/core/entity-api.ts
+++ b/src/core/entity-api.ts
@@ -1,5 +1,6 @@
 import type { Context, EntityConfiguration } from '../types';
 import type { EntityManager } from './entity-manager';
+import type { EntityDataManager } from './entity-data-manager';
 import type { ValidationManager } from './validation-manager';
 import type { PermissionManager } from './permission-manager';
 import type { WorkflowManager } from './workflow-manager';
@@ -12,6 +13,7 @@ export class EntityAPI {
   constructor(
     private readonly entityName: string,
     private readonly entityManager: EntityManager,
+    private readonly entityDataManager: EntityDataManager,
     private readonly validationManager: ValidationManager,
     private readonly permissionManager: PermissionManager,
     private readonly workflowManager: WorkflowManager,
@@ -27,7 +29,7 @@ export class EntityAPI {
     await this.enforcePermission(entityConfig, 'create', contextWithTenant);
     await this.validateData(entityConfig, data, 'create');
 
-    const result = await this.entityManager.insertData(entityConfig, data, contextWithTenant);
+    const result = await this.entityDataManager.insertData(entityConfig, data, contextWithTenant);
 
     await this.workflowManager.executeWorkflows(entityConfig, 'create', null, result, contextWithTenant);
 
@@ -47,7 +49,7 @@ export class EntityAPI {
       operator: 'eq'
     }));
 
-    return this.entityManager.findData(entityConfig, conditions, {}, contextWithTenant);
+    return this.entityDataManager.findData(entityConfig, conditions, {}, contextWithTenant);
   }
 
   async update(id: string | number, data: Record<string, any>, context: Context = {}) {
@@ -57,8 +59,8 @@ export class EntityAPI {
     await this.enforcePermission(entityConfig, 'update', contextWithTenant);
     await this.validateData(entityConfig, data, 'update');
 
-    const oldData = await this.entityManager.findByIdData(entityConfig, id, contextWithTenant);
-    const result = await this.entityManager.updateData(entityConfig, id, data, contextWithTenant);
+    const oldData = await this.entityDataManager.findByIdData(entityConfig, id, contextWithTenant);
+    const result = await this.entityDataManager.updateData(entityConfig, id, data, contextWithTenant);
 
     await this.workflowManager.executeWorkflows(entityConfig, 'update', oldData, result, contextWithTenant);
 
@@ -71,8 +73,8 @@ export class EntityAPI {
 
     await this.enforcePermission(entityConfig, 'delete', contextWithTenant);
 
-    const oldData = await this.entityManager.findByIdData(entityConfig, id, contextWithTenant);
-    const result = await this.entityManager.deleteData(entityConfig, id, contextWithTenant);
+    const oldData = await this.entityDataManager.findByIdData(entityConfig, id, contextWithTenant);
+    const result = await this.entityDataManager.deleteData(entityConfig, id, contextWithTenant);
 
     await this.workflowManager.executeWorkflows(entityConfig, 'delete', oldData, null, contextWithTenant);
 
@@ -85,7 +87,7 @@ export class EntityAPI {
 
     await this.enforcePermission(entityConfig, 'read', contextWithTenant);
 
-    return this.entityManager.findByIdData(entityConfig, id, contextWithTenant);
+    return this.entityDataManager.findByIdData(entityConfig, id, contextWithTenant);
   }
 
   // ----- Schema and Configuration getters -----

--- a/src/core/entity-data-manager.ts
+++ b/src/core/entity-data-manager.ts
@@ -1,0 +1,323 @@
+/**
+ * EntityDataManager - Entity Data Operations
+ * Responsible for entity data CRUD operations and table management
+ * 
+ * This class handles:
+ * - Raw data operations (CRUD)
+ * - Table creation and management
+ * - Data transformation and system field management
+ */
+import { DatabaseManager } from '../database/database-manager';
+import { FluentQueryBuilder } from '../database/fluent-query-builder';
+import { EntityConfiguration, Context, RLSConditions } from '../types';
+import { generateId } from '../utils/id-generation';
+import { getCurrentTimestamp } from '../utils/date-helpers';
+
+/**
+ * EntityDataManager class - Entity Data Operations
+ * 
+ * Single Responsibility: Handle entity data CRUD operations
+ */
+export class EntityDataManager {
+  private databaseManager: DatabaseManager;
+
+  /**
+   * Create a new EntityDataManager instance
+   * @param databaseManager Database manager
+   */
+  constructor(databaseManager: DatabaseManager) {
+    this.databaseManager = databaseManager;
+  }
+
+  // === DATA ACCESS METHODS ===
+
+  /**
+   * Raw data insertion
+   * @param entityConfig Entity configuration
+   * @param data Entity data
+   * @param context User context
+   * @returns Created entity record
+   */
+  async insertData(
+    entityConfig: EntityConfiguration,
+    data: Record<string, any>,
+    context: Context = {}
+  ): Promise<Record<string, any>> {
+    // Ensure entity table exists
+    await this.ensureEntityTable(entityConfig);
+
+    // Generate ID if not provided
+    if (!data.id) {
+      data.id = generateId();
+    }
+
+    // Add system fields
+    const timestamp = getCurrentTimestamp();
+    data.created_at = timestamp;
+    data.updated_at = timestamp;
+
+    // Add creator ID if available in context
+    if (context.user?.id) {
+      data.created_by = context.user.id;
+      data.updated_by = context.user.id;
+    }
+
+    // Use fluent database interface
+    const tableName = entityConfig.entity.table_name;
+    const tenantId = context.tenantId || 'default';
+    const result = await this.db(tableName, tenantId).insert(data);
+
+    if (result.changes === 0) {
+      throw new Error(`Failed to create ${tableName} record`);
+    }
+
+    // For INSERT with RETURNING, we need to get the inserted record
+    const insertedId = result.lastInsertId;
+    if (insertedId) {
+      const insertedRecord = await this.findByIdData(entityConfig, insertedId, context);
+      return insertedRecord || { id: insertedId, ...data };
+    }
+
+    // Fallback: return the data with a generated ID
+    return { id: generateId(), ...data };
+  }
+
+  /**
+   * Raw data retrieval by ID
+   * @param entityConfig Entity configuration
+   * @param id Record ID
+   * @param context User context
+   * @param rlsConditions RLS conditions (optional)
+   * @returns Entity record or null if not found
+   */
+  async findByIdData(
+    entityConfig: EntityConfiguration,
+    id: string | number,
+    context: Context = {},
+    rlsConditions?: RLSConditions
+  ): Promise<Record<string, any> | null> {
+    const tableName = entityConfig.entity.table_name;
+    const tenantId = context.tenantId || 'default';
+    
+    // Use fluent database interface
+    let query = this.db(tableName, tenantId).where('id', id);
+    
+    // Add RLS conditions if provided
+    if (rlsConditions?.conditions) {
+      for (const condition of rlsConditions.conditions) {
+        query = query.where(condition.field, condition.operator, condition.value);
+      }
+    }
+
+    return await query.first();
+  }
+
+  /**
+   * Raw data update
+   * @param entityConfig Entity configuration
+   * @param id Record ID
+   * @param data Update data
+   * @param context User context
+   * @param rlsConditions RLS conditions (optional)
+   * @returns Updated entity record
+   */
+  async updateData(
+    entityConfig: EntityConfiguration,
+    id: string | number,
+    data: Record<string, any>,
+    context: Context = {},
+    rlsConditions?: RLSConditions
+  ): Promise<Record<string, any>> {
+    const tableName = entityConfig.entity.table_name;
+    const tenantId = context.tenantId || 'default';
+    
+    // Add system fields
+    data.updated_at = getCurrentTimestamp();
+    
+    // Add updater ID if available in context
+    if (context.user?.id) {
+      data.updated_by = context.user.id;
+    }
+
+    // Remove ID from update data if present
+    if ('id' in data) {
+      delete data.id;
+    }
+
+    // Use fluent database interface
+    let query = this.db(tableName, tenantId).where('id', id);
+    
+    // Add RLS conditions if provided
+    if (rlsConditions?.conditions) {
+      for (const condition of rlsConditions.conditions) {
+        query = query.where(condition.field, condition.operator, condition.value);
+      }
+    }
+
+    const result = await query.update(data);
+    if (result.changes === 0) {
+      throw new Error(`Record not found or permission denied: ${tableName} with ID ${id}`);
+    }
+
+    // Return updated record
+    return await this.findByIdData(entityConfig, id, context, rlsConditions) || { id, ...data };
+  }
+
+  /**
+   * Raw data deletion
+   * @param entityConfig Entity configuration
+   * @param id Record ID
+   * @param context User context
+   * @param rlsConditions RLS conditions (optional)
+   * @returns True if record was deleted
+   */
+  async deleteData(
+    entityConfig: EntityConfiguration,
+    id: string | number,
+    context: Context = {},
+    rlsConditions?: RLSConditions
+  ): Promise<boolean> {
+    const tableName = entityConfig.entity.table_name;
+    const tenantId = context.tenantId || 'default';
+    
+    // Use fluent database interface
+    let query = this.db(tableName, tenantId).where('id', id);
+    
+    // Add RLS conditions if provided
+    if (rlsConditions?.conditions) {
+      for (const condition of rlsConditions.conditions) {
+        query = query.where(condition.field, condition.operator, condition.value);
+      }
+    }
+
+    const result = await query.delete();
+    return result.changes > 0;
+  }
+
+  /**
+   * Raw data finding with conditions
+   * @param entityConfig Entity configuration
+   * @param conditions Query conditions
+   * @param options Query options
+   * @param context User context
+   * @param rlsConditions RLS conditions (optional)
+   * @returns Array of entity records
+   */
+  async findData(
+    entityConfig: EntityConfiguration,
+    conditions: any[] = [],
+    options: {
+      fields?: string[];
+      sort?: { field: string; direction: 'ASC' | 'DESC' }[];
+      limit?: number;
+      offset?: number;
+    } = {},
+    context: Context = {},
+    rlsConditions?: RLSConditions
+  ): Promise<Record<string, any>[]> {
+    const tableName = entityConfig.entity.table_name;
+    const tenantId = context.tenantId || 'default';
+    
+    // Start building query
+    let query = this.db(tableName, tenantId);
+
+    // Add RLS conditions first
+    if (rlsConditions?.conditions) {
+      for (const condition of rlsConditions.conditions) {
+        query = query.where(condition.field, condition.operator, condition.value);
+      }
+    }
+
+    // Add search conditions
+    for (const condition of conditions) {
+      query = query.where(condition.field, condition.operator, condition.value);
+    }
+
+    // Add field selection
+    if (options.fields && options.fields.length > 0) {
+      query = query.select(options.fields);
+    }
+
+    // Add sorting
+    if (options.sort && options.sort.length > 0) {
+      for (const sort of options.sort) {
+        query = query.orderBy(sort.field, sort.direction);
+      }
+    }
+
+    // Add pagination
+    if (options.limit) {
+      query = query.limit(options.limit);
+    }
+    if (options.offset) {
+      query = query.offset(options.offset);
+    }
+
+    return await query.get();
+  }
+
+  // === TABLE MANAGEMENT ===
+
+  /**
+   * Ensure entity table exists
+   */
+  async ensureEntityTable(entityConfig: EntityConfiguration): Promise<void> {
+    const tableName = entityConfig.entity.table_name;
+    const exists = await this.databaseManager.tableExists(tableName);
+    
+    if (!exists) {
+      // Build column definitions
+      const columns = entityConfig.fields.map((field: any) => ({
+        name: field.name,
+        type: this.getSqlType(field.type),
+        primaryKey: field.name === 'id',
+        notNull: field.is_required || field.name === 'id',
+        unique: field.is_unique,
+        default: field.default_value
+      }));
+
+      // Add system columns
+      columns.push(
+        { name: 'created_at', type: 'DATETIME', primaryKey: false, notNull: true, unique: false, default: undefined },
+        { name: 'updated_at', type: 'DATETIME', primaryKey: false, notNull: true, unique: false, default: undefined },
+        { name: 'created_by', type: 'VARCHAR(255)', primaryKey: false, notNull: false, unique: false, default: undefined },
+        { name: 'updated_by', type: 'VARCHAR(255)', primaryKey: false, notNull: false, unique: false, default: undefined }
+      );
+
+      await this.databaseManager.createTable(tableName, columns);
+    }
+  }
+
+  // === PRIVATE HELPER METHODS ===
+
+  /**
+   * Create a fluent query builder for a table
+   */
+  private db(tableName: string, tenantId: string = 'default'): FluentQueryBuilder {
+    return this.databaseManager.db(tableName, tenantId);
+  }
+
+  /**
+   * Get SQL type for field type
+   */
+  private getSqlType(fieldType: string): string {
+    switch (fieldType) {
+      case 'string':
+      case 'email':
+      case 'url':
+      case 'text':
+      case 'uuid':
+        return 'VARCHAR(255)';
+      case 'number':
+        return 'DECIMAL(10,2)';
+      case 'boolean':
+        return 'BOOLEAN';
+      case 'date':
+        return 'DATE';
+      case 'datetime':
+        return 'DATETIME';
+      default:
+        return 'VARCHAR(255)';
+    }
+  }
+}

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -2,6 +2,9 @@
  * Database adapter interface and factory
  */
 import { DatabaseError } from '../errors';
+import { SQLiteAdapter } from './adapters/sqlite';
+import { PostgresAdapter } from './adapters/postgres';
+import { InMemoryAdapter } from './adapters/inmemory';
 
 /**
  * Database adapter configuration options
@@ -229,20 +232,10 @@ export abstract class DatabaseAdapter {
   static createSync(type = 'sqlite', config: DatabaseAdapterConfig = {}): DatabaseAdapter {
     switch (type.toLowerCase()) {
       case 'sqlite':
-        // Import SQLiteAdapter
-        // Using dynamic import would be better but we need synchronous behavior here
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { SQLiteAdapter } = require('./adapters/sqlite') as { SQLiteAdapter: new (config: DatabaseAdapterConfig) => DatabaseAdapter };
         return new SQLiteAdapter(config);
       case 'postgres':
-        // Import PostgresAdapter
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { PostgresAdapter } = require('./adapters/postgres') as { PostgresAdapter: new (config: DatabaseAdapterConfig) => DatabaseAdapter };
         return new PostgresAdapter(config);
       case 'inmemory':
-        // Import InMemoryAdapter
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { InMemoryAdapter } = require('./adapters/inmemory') as { InMemoryAdapter: new (config: DatabaseAdapterConfig) => DatabaseAdapter };
         return new InMemoryAdapter(config);
       default:
         throw new DatabaseError('create', new Error(`Unsupported adapter type: ${type}`));

--- a/src/utils/id-generation.ts
+++ b/src/utils/id-generation.ts
@@ -2,6 +2,7 @@
  * ID Generation Utilities
  * Centralized ID generation functions for SchemaKit
  */
+import * as nodeCrypto from 'crypto';
 
 /**
  * Generate a simple UUID v4
@@ -28,8 +29,7 @@ export function generateUUID(): string {
   
   // Check if we're in Node.js with crypto module
   try {
-    const crypto = require('crypto');
-    return crypto.randomUUID();
+    return nodeCrypto.randomUUID();
   } catch (e) {
     // Fall back to our simple implementation
     return generateId();


### PR DESCRIPTION
Refactor `EntityManager` to address its 'God Object' design and remove internal `require` statements.

The original `EntityManager` violated the Single Responsibility Principle by handling entity configuration, data operations, and API instance creation. This PR splits these responsibilities into a focused `EntityManager` (config only), a new `EntityDataManager` (data CRUD), and a new `EntityAPIFactory` (API instance management). Additionally, all runtime `require()` calls have been migrated to ES6 imports for better module management and adherence to modern standards.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-799ac5ea-c3ea-4c58-afb7-8078628b3bef) · [Cursor](https://cursor.com/background-agent?bcId=bc-799ac5ea-c3ea-4c58-afb7-8078628b3bef)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)